### PR TITLE
Add "Back to Top" Links in README for Better Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Welcome to your Lovable project
+<!-- top -->
 
 ## Project info
 
@@ -71,3 +72,10 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+
+<p align="center">
+  <a href="#top" style="font-size: 18px; padding: 8px 16px; display: inline-block; border: 1px solid #ccc; border-radius: 6px; text-decoration: none;">
+    ⬆️ Back to Top
+  </a>
+</p>


### PR DESCRIPTION
The current README.md is too long and contains multiple sections. Scrolling through it can be cumbersome, especially for new users or contributors accessing it on smaller screens.

💡 Proposed Solution
Add [🔝 Back to Top] links at the end of major sections in the README

Optionally add a top anchor like (though GitHub supports #readme by default)

Maintain consistent formatting across all sections

Please assign this as level 1